### PR TITLE
[docs](web): description 

### DIFF
--- a/JekylTitleHeadings.md
+++ b/JekylTitleHeadings.md
@@ -12,9 +12,9 @@
 
 | Jekyll _config.yml<br />titles_from_headings<br />display results: |  enabled: | strip_title: | collections: |
 |---|---|---|---|
-| double headers<br />no JekyllTestBed  | no value[^11] | no value[^11] | no value[^11] |
-|   | false | false | false |
-|   | false | false | true |
+| • double headers<br />• no JekyllTestBed  | no value[^11] | no value[^11] | no value[^11] |
+| • No double headers <br />• But no page links | false | false | false |
+| • No double headers <br />• But no page links  | false | false | true |
 |   | false | true | false |
 |   | false | true | true |
 |   | true | false | false |

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 | Jekyll _config.yml<br />titles_from_headings<br />display results: |  enabled: | strip_title: | collections: |
 |---|---|---|---|
-| double headers<br />no JekyllTestBed  | no value[^11] | no value[^11] | no value[^11] |
+| • double headers<br />• no JekyllTestBed  | no value[^11] | no value[^11] | no value[^11] |
 | • No double headers <br />• But no page links | false | false | false |
-|   | false | false | true |
+| • No double headers <br />• But no page links  | false | false | true |
 |   | false | true | false |
 |   | false | true | true |
 |   | true | false | false |

--- a/_config.yml
+++ b/_config.yml
@@ -53,8 +53,8 @@ plugins:
 # 2024-05-06 This looks like the right settings where Jekyll won't display two H1s.
 titles_from_headings:
   enabled: false
-  strip_title: false
-  collections: true
+  strip_title: true
+  collections: false
   
 # Optional. The default date format, used if none is specified in the tag.
 last-modified-at:


### PR DESCRIPTION
- titles_from_headings:
   - enabled: fals
   - strip_title: true
   - collections: false

| Jekyll _config.yml<br />titles_from_headings<br />display results: |  enabled: | strip_title: | collections: |
|---|---|---|---|
| • double headers<br />• no JekyllTestBed  | no value[^11] | no value[^11] | no value[^11] |
| • No double headers <br />• But no page links | false | false | false |
| • No double headers <br />• But no page links  | false | false | true |
|   | false | true | false |
|   | false | true | true |
|   | true | false | false |
|   | true | false | true |
|   | true | true | false |
|   | true | true | true |

[^11]: Commented out.
