### PR TITLE
[docs](web): no dice 

### DIFF
--- a/JekyllTitleHeadings.md
+++ b/JekyllTitleHeadings.md
@@ -18,7 +18,7 @@
 | • No double headers <br />• But no page links  | false | true | false |
 | • No double headers <br />• But no page links  | false | true | true |
 | • double headers<br />• no JekyllTestBed  | true | false | false |
-|   | true | false | true |
+| • double headers <br />no page title | true | false | true |
 |   | true | true | false |
 |   | true | true | true |
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | • No double headers <br />• But no page links  | false | true | false |
 | • No double headers <br />• But no page links  | false | true | true |
 | • double headers<br />• no JekyllTestBed  | true | false | false |
-|   | true | false | true |
+| • double headers <br />no page title | true | false | true |
 |   | true | true | false |
 |   | true | true | true |
 

--- a/_config.yml
+++ b/_config.yml
@@ -53,8 +53,8 @@ plugins:
 # 2024-05-06 This looks like the right settings where Jekyll won't display two H1s.
 titles_from_headings:
   enabled: true
-  strip_title: false
-  collections: true
+  strip_title: true
+  collections: false
   
 # Optional. The default date format, used if none is specified in the tag.
 last-modified-at:


### PR DESCRIPTION
| Jekyll _config.yml<br />titles_from_headings<br />display results: |  enabled: | strip_title: | collections: |
|---|---|---|---|
| • double headers<br />• no JekyllTestBed  | no value[^11] | no value[^11] | no value[^11] |
| • No double headers <br />• But no page links | false | false | false |
| • No double headers <br />• But no page links  | false | false | true |
| • No double headers <br />• But no page links  | false | true | false |
| • No double headers <br />• But no page links  | false | true | true |
| • double headers<br />• no JekyllTestBed  | true | false | false |
| • double headers <br />no page title | true | false | true |
|   | true | true | false |
|   | true | true | true |

[^11]: Commented out.
